### PR TITLE
Exporting DataFrame and Date constructors

### DIFF
--- a/src/TSx.jl
+++ b/src/TSx.jl
@@ -61,8 +61,8 @@ export TS,
     summary,
     tail,
     rollapply,
-    vcat, 
-    DataFrame, 
+    vcat,
+    DataFrame,
     Date
 
 include("TS.jl")

--- a/src/TSx.jl
+++ b/src/TSx.jl
@@ -61,7 +61,9 @@ export TS,
     summary,
     tail,
     rollapply,
-    vcat
+    vcat, 
+    DataFrame, 
+    Date
 
 include("TS.jl")
 include("utils.jl")


### PR DESCRIPTION
DataFrame and Date objects are required as inputs from users for many objectives. I suggest exporting the constructors, so the users don't have to import them in most cases. 