### PR TITLE
Changes to pctchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
+# Editor
+.vscode
+
+# Julia tests cache
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
+
+# Julia docs cache
 /Manifest.toml
 /docs/Manifest.toml
 /docs/build/

--- a/src/TS.jl
+++ b/src/TS.jl
@@ -278,3 +278,6 @@ function TS(coredata::AbstractArray{T,2}, index::AbstractVector{V}) where {T, V}
     df = DataFrame(coredata, :auto, copycols=true)
     TS(df, index)
 end
+
+# To avoid error on using a TS to create a TS
+TS(ts::TS) = ts

--- a/src/pctchange.jl
+++ b/src/pctchange.jl
@@ -2,12 +2,13 @@
 # Percent Change
 
 ```julia
-pctchange(ts::TS, periods::Int = 1; log = false)
+pctchange(ts::TS; periods::Int = 1, log = false)
 ```
 
 Return the percentage change between successive row elements.
 Default is the element in the next row. `periods` defines the number
-of rows to be shifted over. The skipped rows are rendered as `missing`.
+of rows to be shifted over, `1` being the default. The skipped rows are 
+rendered as `missing`.
 
 `log` is one of `false` (the default), `:log` and `:log10`. If `log == :log`, 
 the percentage change is computed as the logarithm of the change. If 
@@ -83,20 +84,27 @@ julia> pctchange(ts, 3)
 
 ```
 """
-function pctchange(ts::TS, periods::Int = 1; log = false)
+function pctchange(ts::TS; periods::Int = 1, log::Any = false)
     if periods <= 0
         error("periods must be a positive int")
     end
 
-    ddf = (ts.coredata[:, Not(:Index)] ./ TSx.lag(ts, periods).coredata[:, Not(:Index)]) .- 1
-    if log == :log
-        ddf = log.(ddf)
+    ddf = (ts.coredata[:, Not(:Index)] ./ TSx.lag(ts, periods).coredata[:, Not(:Index)])
+    
+    if log == false
+        ddf = ddf .- 1
+    elseif log == :log
+        ddf = Base.log.(ddf)
     elseif log == :log10
-        ddf = log10.(ddf)
-    elseif log != false
-        @warning "log must be one of false, :log or :log10"
+        ddf = Base.log10.(ddf)
+    else
+        @warn "log must be one of false, :log or :log10"
     end
 
     insertcols!(ddf, 1, "Index" => ts.coredata[:, :Index])
-    TS(ddf, :Index)
+    return TS(ddf, :Index)
 end
+
+# function pctchange(ts::TS, periods::Int = 1; log::Any = false) 
+#     return pctchange(ts; periods = periods, log = log)
+# end

--- a/src/pctchange.jl
+++ b/src/pctchange.jl
@@ -2,14 +2,21 @@
 # Percent Change
 
 ```julia
-pctchange(ts::TS, periods::Int = 1)
+pctchange(ts::TS, periods::Int = 1; log = false)
 ```
 
 Return the percentage change between successive row elements.
 Default is the element in the next row. `periods` defines the number
 of rows to be shifted over. The skipped rows are rendered as `missing`.
 
-`pctchange` returns an error if column type does not have the method `/`.
+`log` is one of `false` (the default), `:log` and `:log10`. If `log == :log`, 
+the percentage change is computed as the logarithm of the change. If 
+`log == :log10`, the percentage change is computed as the logarithm of
+the change in base 10. Other values are ignored with a warning message.
+
+`pctchange` returns an error if: 
+    - the column type does not have the method `/`; or,
+    - the column type does not have the method `log` or `log10` when specified.
 
 # Examples
 ```jldoctest; setup = :(using TSx, DataFrames, Dates, Random, Statistics)
@@ -76,13 +83,20 @@ julia> pctchange(ts, 3)
 
 ```
 """
-
-# Pctchange
-function pctchange(ts::TS, periods::Int = 1)
+function pctchange(ts::TS, periods::Int = 1; log = false)
     if periods <= 0
         error("periods must be a positive int")
     end
+
     ddf = (ts.coredata[:, Not(:Index)] ./ TSx.lag(ts, periods).coredata[:, Not(:Index)]) .- 1
+    if log == :log
+        ddf = log.(ddf)
+    elseif log == :log10
+        ddf = log10.(ddf)
+    elseif log != false
+        @warning "log must be one of false, :log or :log10"
+    end
+
     insertcols!(ddf, 1, "Index" => ts.coredata[:, :Index])
     TS(ddf, :Index)
 end


### PR DESCRIPTION
Change signature to make periods optional still defaulting to 1.

Add option to use log or log10 changes (often used in financial data).

Minor: add constructor TS(df::TS) = df. That is, passing a TS to a constructor does nothing.