### PR TITLE
add keyword argument to control column names renaming in `apply()`

### DIFF
--- a/docs/src/user_guide.md
+++ b/docs/src/user_guide.md
@@ -397,6 +397,35 @@ julia> apply(ts, Week, Statistics.std, last)
  2008-03-06   0.702384
         43 rows omitted
 
+# do not rename column
+julia> apply(ts, Week, Statistics.std, last, renamecols=false)
+(62 x 1) TS with Date Index
+
+ Index       value
+ Date        Float64
+──────────────────────
+ 2007-01-07  1.52077
+ 2007-01-14  0.910942
+ 2007-01-21  0.876362
+ 2007-01-28  1.08075
+ 2007-02-04  1.17684
+ 2007-02-11  1.40065
+ 2007-02-18  0.630415
+ 2007-02-25  1.38134
+ 2007-03-04  1.10601
+ 2007-03-11  1.51014
+     ⋮          ⋮
+ 2008-01-13  1.47589
+ 2008-01-20  0.923073
+ 2008-01-27  0.885798
+ 2008-02-03  1.16116
+ 2008-02-10  1.22311
+ 2008-02-17  1.40016
+ 2008-02-24  0.680589
+ 2008-03-02  1.37616
+ 2008-03-06  0.702384
+       43 rows omitted
+
 ```
 
 ## Joins: Row and column binding with other objects
@@ -830,8 +859,8 @@ julia> Matrix(ts)
 # use the underlying DataFrame for other operations
 julia> select(ts.coredata, :Index, :value, DataFrames.nrow)
 431×3 DataFrame
- Row │ Index       value     nrow  
-     │ Date        Float64   Int64 
+ Row │ Index       value     nrow
+     │ Date        Float64   Int64
 ─────┼─────────────────────────────
    1 │ 2007-01-01  10.1248     431
    2 │ 2007-01-02  10.3424     431

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -131,11 +131,7 @@ julia> show(ts_weekly[1:10])
 
 ```
 """
-function apply(ts::TS,
-               period::Union{T,Type{T}},
-               fun::V,
-               index_at::Function=first;
-               renamecols::Bool=true) where {T<:Union{DatePeriod,TimePeriod}, V<:Function}
+function apply(ts::TS, period::Union{T,Type{T}}, fun::V, index_at::Function=first; renamecols::Bool=true) where {T<:Union{DatePeriod,TimePeriod}, V<:Function}
 
     local tmp_col::String = get_tmp_colname(names(ts.coredata))
     sdf = transform(ts.coredata, :Index => (i -> Dates.floor.(i, period)) => tmp_col)

--- a/src/apply.jl
+++ b/src/apply.jl
@@ -4,7 +4,8 @@
 apply(ts::TS,
       period::Union{T,Type{T}},
       fun::V,
-      index_at::Function=first)
+      index_at::Function=first;
+      renamecols::Bool=true)
      where {T <: Union{DatePeriod,TimePeriod}, V <: Function}
 ```
 
@@ -21,6 +22,12 @@ By default, the method uses the first value of the index within the
 period to index the resulting aggregated object. This behaviour can be
 controlled by `index_at` argument which can take `first` or `last` as
 an input.
+
+# Keyword arguments
+* `renamecols::Bool=true`: whether to rename column names in the
+   resulting object. If `false`, the column name is automatically
+   generated based on the name of `fun` otherwise existing column
+   names are used.
 
 # Examples
 ```jldoctest; setup = :(using TSx, DataFrames, Dates, Random, Statistics)
@@ -124,14 +131,20 @@ julia> show(ts_weekly[1:10])
 
 ```
 """
-function apply(ts::TS, period::Union{T,Type{T}}, fun::V, index_at::Function=first) where {T<:Union{DatePeriod,TimePeriod}, V<:Function}
+function apply(ts::TS,
+               period::Union{T,Type{T}},
+               fun::V,
+               index_at::Function=first;
+               renamecols::Bool=true) where {T<:Union{DatePeriod,TimePeriod}, V<:Function}
+
     local tmp_col::String = get_tmp_colname(names(ts.coredata))
     sdf = transform(ts.coredata, :Index => (i -> Dates.floor.(i, period)) => tmp_col)
     gd = groupby(sdf, tmp_col)
     df = combine(gd,
                  :Index => index_at => :Index,
                  Not(["Index", tmp_col]) .=> fun,
-                 keepkeys=false)
+                 keepkeys=false,
+                 renamecols=renamecols)
     TS(df, :Index)
 end
 


### PR DESCRIPTION
Refs issue #28.