### PR TITLE
Addition of column rename function

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -297,7 +297,8 @@ end
 """
 # Column Rename
 ```julia
-rename!(ts::TS, colnames::AbstractVector{T}) where {T<:Union{String, Symbol}}
+rename!(ts::TS, colnames::AbstractVector{String})
+rename!(ts::TS, colnames::AbstractVector{Symbol})
 ```
 
 Renames columns of `ts` to the values in `colnames`, in order. Input

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -341,13 +341,24 @@ Int64  Int64  Int64
 ```
 """
 
-function rename!(ts::TS, colnames::AbstractVector{T}) where {T<:Union{String, Symbol}}
+function rename!(ts::TS, colnames::AbstractVector{String})
     idx = findall(i -> i == "Index", colnames)
     if length(idx) > 0
         error("Column name `Index` not allowed in TS object")
     end
     cols = copy(colnames)
     insert!(cols, 1, "Index")
+    DataFrames.rename!(ts.coredata, cols)
+    return ts
+end
+
+function rename!(ts::TS, colnames::AbstractVector{Symbol})
+    idx = findall(i -> i == :Index, colnames)
+    if length(idx) > 0
+        error("Column name `Index` not allowed in TS object")
+    end
+    cols = copy(colnames)
+    insert!(cols, 1, :Index)
     DataFrames.rename!(ts.coredata, cols)
     return ts
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -292,3 +292,62 @@ julia> tail(TS(1:100))
 function tail(ts::TS, n::Int = 10)
     TS(DataFrames.last(ts.coredata, n))
 end
+
+
+"""
+# Column Rename
+```julia
+rename!(ts::TS, colnames::AbstractVector{T}) where {T<:Union{String, Symbol}}
+```
+
+Renames columns of `ts` to the values in `colnames`, in order. Input
+is a vector of either Strings or Symbols. The `Index` column name is reserved,
+and `rename!()` will throw an error if `colnames` contains the name `Index`.
+
+```jldoctest; setup = :(using TSx, DataFrames, Dates, Random)
+julia> ts
+(100 x 2) TS with Int64 Index
+
+ Index  x1     x2    
+ Int64  Int64  Int64 
+─────────────────────
+     1      2      1
+     2      3      2
+     3      4      3
+     4      5      4
+   ⋮      ⋮      ⋮
+    97     98     97
+    98     99     98
+    99    100     99
+   100    101    100
+      92 rows omitted
+
+julia> rename!(ts, ["Col1", "Col2"])
+(100 x 2) TS with Int64 Index
+
+Index  Col1   Col2  
+Int64  Int64  Int64 
+─────────────────────
+    1      2      1
+    2      3      2
+    3      4      3
+    4      5      4
+  ⋮      ⋮      ⋮
+   97     98     97
+   98     99     98
+   99    100     99
+  100    101    100
+     92 rows omitted
+```
+"""
+
+function rename!(ts::TS, colnames::AbstractVector{T}) where {T<:Union{String, Symbol}}
+    idx = findall(i -> i == "Index", colnames)
+    if length(idx) > 0
+        error("Column name `Index` not allowed in TS object")
+    end
+    cols = copy(colnames)
+    insert!(cols, 1, "Index")
+    DataFrames.rename!(ts.coredata, cols)
+    return ts
+end


### PR DESCRIPTION
A new column rename function `rename!()` for TS was added. The function renames the columns to newly defined values in-place. Documentation is also provided. The function is stored in the `utils.jl` file.