### PR TITLE
add function to check for consistency of Index, refs #29

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -363,3 +363,11 @@ function rename!(ts::TS, colnames::AbstractVector{Symbol})
     DataFrames.rename!(ts.coredata, cols)
     return ts
 end
+
+"""
+Internal function to check consistency of the Index of a TS
+object.
+"""
+function _check_consistency(ts::TS)::Bool
+    issorted(index(ts))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,3 +31,7 @@ end
 @testset "index()" begin
     include("index.jl")
 end
+
+@testset "utils" begin
+    include("utils.jl")
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,9 @@
+###
+# Test _check_consistency()
+###
+ts = TS(data_vector, 1:length(data_vector));
+@test TSx._check_consistency(ts) == true
+
+ts.coredata.Index = sample(index_integer, length(data_vector), replace=true);
+@test TSx._check_consistency(ts) == false
+####


### PR DESCRIPTION
Basic consistency check to validate sanity of `TS` object. Currently, only checks whether the `Index` is sorted or not.