### PR TITLE
Accept column names in `TSx.describe()`.

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,14 +21,39 @@ julia> describe(ts)
 ─────┼───────────────────────────────────────────────────────────────────────────
    1 │ Index        5.5       1      5.5     10         0  Int64
    2 │ x1           2.75      2      3.0      4         2  Union{Missing, Int64}
+julia> describe(ts, cols=:Index)
+1×7 DataFrame
+ Row │ variable  mean     min    median   max    nmissing  eltype
+     │ Symbol    Float64  Int64  Float64  Int64  Int64     DataType
+─────┼──────────────────────────────────────────────────────────────
+   1 │ Index         5.5      1      5.5     10         0  Int64
+julia> describe(ts, :min, :max, cols=:x1)
+1×3 DataFrame
+ Row │ variable  min    max
+     │ Symbol    Int64  Int64
+─────┼────────────────────────
+   1 │ x1            2      4
 
 ```
 """
-function describe(io::IO, ts::TS)
-    DataFrames.describe(ts.coredata)
+function describe(io::IO, ts::TS; cols=:)
+    DataFrames.describe(ts.coredata; cols=cols)
 end
-TSx.describe(ts::TS) = TSx.describe(stdout, ts)
+TSx.describe(ts::TS; cols=:) = TSx.describe(stdout, ts; cols=cols)
 
+function describe(
+    io::IO,
+    ts::TS,
+    stats::Union{Symbol, Pair{<:Base.Callable, <:Union{Symbol, AbstractString}}}...;
+    cols=:
+)
+    DataFrames.describe(ts.coredata, stats...; cols=cols)
+end
+TSx.describe(
+    ts::TS,
+    stats::Union{Symbol, Pair{<:Base.Callable, <:Union{Symbol, AbstractString}}}...;
+    cols=:
+) = TSx.describe(stdout, ts, stats...; cols=cols)
 
 function Base.show(io::IO, ts::TS)
     println("(", TSx.nrow(ts), " x ", TSx.ncol(ts), ") TS with ", eltype(index(ts)), " Index")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,12 +2,16 @@
 # Summary statistics
 
 ```julia
-describe(ts::TS)
+describe(ts::TS; cols=:)
+describe(ts::TS, stats::Union{Symbol, Pair}...; cols=:)
 ```
 
 Compute summary statistics of `ts`. The output is a `DataFrame`
 containing standard statistics along with number of missing values and
-data types of columns.
+data types of columns. The `cols` keyword controls which subset of columns
+from `ts` to be selected. The `stats` keyword is used to control which
+summary statistics are to be printed. For more information about these
+keywords, check out the corresponding [documentation from DataFrames.jl](https://dataframes.juliadata.org/stable/lib/functions/#DataAPI.describe).
 
 # Examples
 ```jldoctest; setup = :(using TSx, DataFrames, Dates, Random, Statistics)
@@ -33,6 +37,19 @@ julia> describe(ts, :min, :max, cols=:x1)
      │ Symbol    Int64  Int64
 ─────┼────────────────────────
    1 │ x1            2      4
+julia> describe(ts, :min, sum => :sum)
+2×3 DataFrame
+ Row │ variable  min    sum
+     │ Symbol    Int64  Int64
+─────┼────────────────────────
+   1 │ Index         1     55
+   2 │ x1            2     22
+julia> describe(ts, :min, sum => :sum, cols=:x1)
+1×3 DataFrame
+ Row │ variable  min    sum
+     │ Symbol    Int64  Int64
+─────┼────────────────────────
+   1 │ x1            2     22
 
 ```
 """


### PR DESCRIPTION
This PR solves https://github.com/xKDR/TSx.jl/issues/50. I've added two additional arguments in `TSx.describe`:

- A keyword argument `cols`, used to specify for which column the summary is to be printed.
- `stats`, to specify what summary stats to print.

So now, one can do something like (please see the docstring for the whole code)

```julia
describe(ts, cols=:Index)
describe(ts, :min, :max, cols=:x1)
```
This is exactly how `DataFrames.describe` is doing it.