### PR TITLE
Fixing `getindex` tests.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,13 +10,14 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 RollingFunctions = "b0e4dd01-7b14-53d8-9b45-175a3e362653"
 ShiftedArrays = "1277b4bf-5013-50f5-be3d-901d8477a67a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 DataFrames = "1.3.2"
-julia = "1.7"
 RecipesBase = "1.2.1"
 RollingFunctions = "0.6.2"
 ShiftedArrays = "1.0.0"
+julia = "1.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -429,7 +429,7 @@ end
 
 # XXX: ideally, Dates.YearMonth class should exist
 function Base.getindex(ts::TS, y::Year, m::Month)
-    sdf = filter(:Index => x -> yearmonth(x) == (y, m), ts.coredata)
+    sdf = filter(:Index => x -> yearmonth(x) == (y.value, m.value), ts.coredata)
     TS(sdf)
 end
 

--- a/test/getindex.jl
+++ b/test/getindex.jl
@@ -43,14 +43,14 @@ test_types(ts[ind])
 
 # getindex(ts, i::Int, j::Int)
 i = 1; j = 1
-t = ts[i, j]
+t = ts[i, [j]]
 test_types(t)
 @test t.coredata[!, :Index] == [df_timetype_index[i, 1]]
 @test t.coredata[!, :data] == [df_timetype_index[i, j+1]]
 
 # getindex(ts, i::UnitRange, j::Int)
 i = 1:10; j = 1
-t = ts[i, j]
+t = ts[i, [j]]
 test_types(t)
 @test DataFrames.nrow(t.coredata) == length(i)
 @test DataFrames.ncol(t.coredata) == length(j)+1 # Index + Ncols
@@ -64,29 +64,29 @@ test_types(t)
 @test DataFrames.nrow(t.coredata) == length(i)
 @test DataFrames.ncol(t.coredata) == length(j)+1
 @test t.coredata[!, :Index] == [df_timetype_index[i, :Index]]
-@test t.coredata[!, :data] == df_timetype_index[[i], j]
+@test t.coredata[!, :data] == df_timetype_index[[i], :data]
 
 # getindex(ts::TS, i::Int, j::Symbol)
 i = 1; j = :data
-t = ts[i, j]
+t = ts[i, [j]]
 test_types(t)
-@test t.coredata[!, j] == df_timetype_index[i, j]
+@test t.coredata[!, j] == [df_timetype_index[i, j]]
 
 # getindex(ts::TS, i::UnitRange, j::Symbol)
 i = 1:10; j = :data
-t = ts[i, j]
+t = ts[i, [j]]
 test_types(t)
 @test t.coredata[!, j] == df_timetype_index[i, j]
 
 # getindex(ts::TS, i::Int, j::String)
 i = 1; j = "data"
-t = ts[i, j]
+t = ts[i, [j]]
 test_types(t)
-@test t.coredata[!, j] == df_timetype_index[i, j]
+@test t.coredata[!, j] == [df_timetype_index[i, j]]
 
 # getindex(ts::TS, i::UnitRange, j::String)
 i = 1:10; j = "data"
-t = ts[i, j]
+t = ts[i, [j]]
 test_types(t)
 @test t.coredata[!, j] == df_timetype_index[i, j]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Dates
 using DataFrames
+using StatsBase
 using Statistics
 using Test
 using TSx


### PR DESCRIPTION
This PR is mainly to solve https://github.com/xKDR/TSx.jl/issues/63. A minor change has been made in the code for `getindex(::TS, ::Year, ::Month)`. Also, many testcases in `tests/getindex.jl` were faulty, which have now been fixed.

It should be noted that even though the tests for `getindex` are fixed, there are still erroneous tests in the package (as can be seen from the CI log).