### PR TITLE
fix show function: make inline results display correctly in vscode

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -73,9 +73,8 @@ TSx.describe(
 ) = TSx.describe(stdout, ts, stats...; cols=cols)
 
 function Base.show(io::IO, ts::TS)
-    println("(", TSx.nrow(ts), " x ", TSx.ncol(ts), ") TS with ", eltype(index(ts)), " Index")
-    println("")
-    DataFrames.show(ts.coredata, show_row_number=false, summary=false)
+    title = "$(TSx.nrow(ts))×$(TSx.ncol(ts)) TS with $(eltype(index(ts))) Index"
+    Base.show(io, ts.coredata; show_row_number=false, title=title)
     return nothing
 end
 Base.show(ts::TS) = show(stdout, ts)


### PR DESCRIPTION
```julia
df = DataFrame(x=1:4,y=rand(4), z='a':'d')
ts = TS(df)
```
before fixed, calling the above block, resulted in:
<img width="602" alt="before_fix" src="https://user-images.githubusercontent.com/73262844/191647940-8db87095-5f6f-42e7-a4b3-59ccbef2c604.png">

after fixed:
<img width="643" alt="fixed" src="https://user-images.githubusercontent.com/73262844/191647969-336273cc-47e7-4223-a680-a0b710f02c02.png">
