### PR TITLE
Adding `MarketData` to doc dependencies.

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+MarketData = "945b72a4-3b13-509d-9b46-1525bb5c06de"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"


### PR DESCRIPTION
The demo finance documentation was giving an error since `MarketData` is not in the documentation dependencies. This should fix it. And perhaps for reasons like this we should do strict checking in doc builds.