### PR TITLE
Fixing `pctchange`.

### DIFF
--- a/src/pctchange.jl
+++ b/src/pctchange.jl
@@ -82,7 +82,7 @@ function pctchange(ts::TS, periods::Int = 1)
     if periods <= 0
         throw(ArgumentError("periods must be a positive int"))
     end
-    ddf = (ts.coredata[:, Not(:Index)] ./ TSx.lag(ts, periods).coredata[:, Not(:Index)]) .- 1
+    ddf = (ts.coredata[:, Not(:Index)] .- TSx.lag(ts, periods).coredata[:, Not(:Index)]) ./ abs.(TSx.lag(ts, periods).coredata[:, Not(:Index)])
     insertcols!(ddf, 1, "Index" => ts.coredata[:, :Index])
     TS(ddf, :Index)
 end

--- a/test/dataobjects.jl
+++ b/test/dataobjects.jl
@@ -5,7 +5,7 @@ COLUMN_NO = 100;
 # global variables
 random(x) = rand(MersenneTwister(123), x);
 data_vector = randn(DATA_SIZE);
-integer_data_vector = rand(1:100, DATA_SIZE);
+integer_data_vector = rand(-100:100, DATA_SIZE);
 data_array = Array([data_vector data_vector]);
 data_array_long = reduce(hcat, [randn(DATA_SIZE) for i in 1:COLUMN_NO])
 

--- a/test/pctchange.jl
+++ b/test/pctchange.jl
@@ -14,7 +14,7 @@ for periods in [1, Int(floor(DATA_SIZE/2))]
     @test isequal(Vector{Missing}(pctchange_ts[1:periods, :x1]), fill(missing, periods))
 
     # other elements are pct changes
-    @test isapprox(pctchange_ts[(periods + 1):TSx.nrow(ts), :x1], (ts[periods + 1:TSx.nrow(ts), :x1] - ts[1:TSx.nrow(ts) - periods, :x1]) ./ ts[1:TSx.nrow(ts) - periods, :x1], atol=1e-5)
+    @test isapprox(pctchange_ts[(periods + 1):TSx.nrow(ts), :x1], (ts[periods + 1:TSx.nrow(ts), :x1] - ts[1:TSx.nrow(ts) - periods, :x1]) ./ abs.(ts[1:TSx.nrow(ts) - periods, :x1]), atol=1e-5)
 end
 
 # when period is atleast DATA_SIZE


### PR DESCRIPTION
This fix addresses https://github.com/xKDR/TSx.jl/issues/105. We have changed the formula for `pctchange` to use an absolute value in the denominator. Also modified the test for `pctchange` to reflect this change.